### PR TITLE
Assignment 5 Creating and Calling Own System Call

### DIFF
--- a/linux-5.4.214/arch/x86/entry/syscalls/syscall_64.tbl
+++ b/linux-5.4.214/arch/x86/entry/syscalls/syscall_64.tbl
@@ -357,7 +357,7 @@
 433	common	fspick			__x64_sys_fspick
 434	common	pidfd_open		__x64_sys_pidfd_open
 435	common	clone3			__x64_sys_clone3/ptregs
-
+436     common  mycall			__x64_sys_mycall
 #
 # x32-specific system call numbers start at 512 to avoid cache impact
 # for native 64-bit operation. The __x32_compat_sys stubs are created

--- a/linux-5.4.214/arch/x86/entry/syscalls/syscall_64.tbl
+++ b/linux-5.4.214/arch/x86/entry/syscalls/syscall_64.tbl
@@ -357,7 +357,7 @@
 433	common	fspick			__x64_sys_fspick
 434	common	pidfd_open		__x64_sys_pidfd_open
 435	common	clone3			__x64_sys_clone3/ptregs
-436     common  mycall			__x64_sys_mycall
+
 #
 # x32-specific system call numbers start at 512 to avoid cache impact
 # for native 64-bit operation. The __x32_compat_sys stubs are created

--- a/linux-5.4.214/include/linux/syscalls.h
+++ b/linux-5.4.214/include/linux/syscalls.h
@@ -1222,6 +1222,7 @@ asmlinkage long sys_old_mmap(struct mmap_arg_struct __user *arg);
  */
 asmlinkage long sys_ni_syscall(void);
 
+asmlinkage long sys_mycall(void);
 #endif /* CONFIG_ARCH_HAS_SYSCALL_WRAPPER */
 
 

--- a/linux-5.4.214/include/uapi/asm-generic/unistd.h
+++ b/linux-5.4.214/include/uapi/asm-generic/unistd.h
@@ -850,10 +850,12 @@ __SYSCALL(__NR_pidfd_open, sys_pidfd_open)
 #define __NR_clone3 435
 __SYSCALL(__NR_clone3, sys_clone3)
 #endif
+#define __NR_mycall 460
+__SYSCALL(__NR_mycall, sys_mycall)
 
 #undef __NR_syscalls
-#define __NR_syscalls 436
-
+//#define __NR_syscalls 436
+#define __NR_syscalls 461
 /*
  * 32 bit systems traditionally used different
  * syscalls for off_t and loff_t arguments, while

--- a/linux-5.4.214/kernel/Makefile
+++ b/linux-5.4.214/kernel/Makefile
@@ -10,7 +10,7 @@ obj-y     = fork.o exec_domain.o panic.o \
 	    extable.o params.o \
 	    kthread.o sys_ni.o nsproxy.o \
 	    notifier.o ksysfs.o cred.o reboot.o \
-	    async.o range.o smpboot.o ucount.o
+	    async.o range.o smpboot.o ucount.o my_syscall.o
 
 obj-$(CONFIG_MODULES) += kmod.o
 obj-$(CONFIG_MULTIUSER) += groups.o

--- a/linux-5.4.214/kernel/my_syscall.c
+++ b/linux-5.4.214/kernel/my_syscall.c
@@ -1,0 +1,7 @@
+#include <linux/syscalls.h>
+
+SYSCALL_DEFINE0(mycall)
+{       
+        printk("System Call Example!\n");
+        return 0;
+} 

--- a/syscall_example.c
+++ b/syscall_example.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <sys/syscall.h>
+
+int main(void)
+{
+	long ret = syscall(460);
+	printf("System Call returned: %ld\n", ret);
+
+	return 0;
+}


### PR DESCRIPTION
- defining system call function
  - creating system call function in `linux-5.4.214/kernel/my_syscall.c`
  - adding code to Makefile `linux-5.4.214/kernel/Makefile`
- registering system call number to the table
  - ARM64
    - `linux-5.4.214/include/uapi/asm-generic/unistd.h`
    - `linux-5.4.214/include/linux/syscalls.h`
- compiling the kernel
  - `make menuconfig`
  - `make -j 4`
  - `make modules -j 4`
  - `sudo make modules_install -j 4`
  - `sudo make install`
- using sys_mycall
  - `syscall_example.c`
  - gcc syscall_example.c -o result: compiling c code
  - ./result: 
  - sudo dmesg: printing out kernel diagnostic message