### PR TITLE
Assignment 9 Profiling Functions with Per-core Calclock

### DIFF
--- a/calclock.h
+++ b/calclock.h
@@ -1,0 +1,12 @@
+#ifndef __CALCLOCK_H
+#define __CALCLOCK_H
+
+#include <linux/time.h>
+
+#define BILLION 1000000000UL
+
+unsigned long long calclock(struct timespec *myclock, 
+		unsigned long long *total_time, unsigned long long *total_clock);
+
+#endif
+

--- a/pxt4/calclock.c
+++ b/pxt4/calclock.c
@@ -1,19 +1,78 @@
 #include "calclock.h"
-unsigned long long calclock(struct timespec *myclock,
-unsigned long long *total_time, unsigned long long *total_count)
-
+/*
+ * * @brief make number as separated with commas
+ *
+ * @number input number
+ * @buffer number string buffer
+ * @return separated number string buffer itself
+ */
+static const char *separate_num(unsigned long long number, char buffer[])
 {
-	unsigned long long timedelay = 0, temp = 0, temp_n = 0;
-	if (myclock[1].tv_nsec >= myclock[0].tv_nsec) {
-		temp = myclock[1].tv_sec - myclock[0].tv_sec; 
-		temp_n = myclock[1].tv_nsec - myclock[0].tv_nsec; 
-		timedelay = BILLION * temp + temp_n;
-	} else {
-		temp = myclock[1].tv_sec - myclock[0].tv_sec - 1;
-		temp_n = BILLION + myclock[1].tv_nsec - myclock[0].tv_nsec;
-	       	timedelay = BILLION * temp + temp_n;
+	char tmp_buff[100]; // temp buffer for characterized numbers
+	char tmp_reverse_buff[100]; // temp buffer for saving reversed numbers
+	int cur, counter = 0, rvs_cur = 0;
+
+	sprintf(tmp_buff, "%llu", number);
+	cur = strlen(tmp_buff);
+
+	for (--cur; cur > -1; cur--) {
+		if (counter == 3) {
+			tmp_reverse_buff[rvs_cur++] = ',';
+			counter = 0;
+			cur++;
+		}
+		else {
+			tmp_reverse_buff[rvs_cur++] = tmp_buff[cur];
+			counter++;
+		}
 	}
-	__sync_fetch_and_add(total_time, timedelay);
-	__sync_fetch_and_add(total_count, 1); 
-	return timedelay;
+
+	cur = 0;
+	for (--rvs_cur; rvs_cur > -1; rvs_cur--) {
+		buffer[cur++] = tmp_reverse_buff[rvs_cur];
+	}
+
+	buffer[cur] = '\0'; // inserting null char
+
+	return buffer;
 }
+
+void __ktprint(int depth, char *func_name, ktime_t time, unsigned long long count)
+{
+	char char_buff[100], char_buff2[100]; // buffer for characterized numbers
+	int percentage;
+	static ktime_t totaltime = 1;
+
+	if (ktime_before(totaltime, time))
+		totaltime = time;
+	percentage = time * 10000 / totaltime;
+
+	printk("%s", "");
+
+	while(depth--)
+		printk(KERN_CONT "    ");
+	printk(KERN_CONT "%s is called ", func_name);
+	printk(KERN_CONT "%s times, ", separate_num(count, char_buff));
+	printk(KERN_CONT "and the time interval is %sns (per thread is %sns)",
+			separate_num((u64)ktime_to_ns(time), char_buff),
+			separate_num((u64)(ktime_to_ns(time) / num_online_cpus()), char_buff2));
+	printk(KERN_CONT " (%d.%.2d%%)\n", percentage/100, percentage%100);
+}
+
+//unsigned long long calclock(struct timespec *myclock,
+//		unsigned long long *total_time, unsigned long long *total_count)
+//{
+//	unsigned long long timedelay = 0, temp = 0, temp_n = 0;
+//	if (myclock[1].tv_nsec >= myclock[0].tv_nsec) {
+//		temp = myclock[1].tv_sec - myclock[0].tv_sec;
+//		temp_n = myclock[1].tv_nsec - myclock[0].tv_nsec;
+//		timedelay = BILLION * temp + temp_n;
+//	} else {
+//		temp = myclock[1].tv_sec - myclock[0].tv_sec - 1;
+//		temp_n = BILLION + myclock[1].tv_nsec - myclock[0].tv_nsec;
+//		timedelay = BILLION * temp + temp_n;
+//	}
+//	__sync_fetch_and_add(total_time, timedelay);
+//	__sync_fetch_and_add(total_count, 1);
+//	return timedelay;
+//}

--- a/pxt4/calclock.c
+++ b/pxt4/calclock.c
@@ -1,6 +1,7 @@
 #include "calclock.h"
-/*
- * * @brief make number as separated with commas
+
+/**
+ * @brief make number as separated with commas
  *
  * @number input number
  * @buffer number string buffer
@@ -53,26 +54,8 @@ void __ktprint(int depth, char *func_name, ktime_t time, unsigned long long coun
 		printk(KERN_CONT "    ");
 	printk(KERN_CONT "%s is called ", func_name);
 	printk(KERN_CONT "%s times, ", separate_num(count, char_buff));
-	printk(KERN_CONT "and the time interval is %sns (per thread is %sns)",
-			separate_num((u64)ktime_to_ns(time), char_buff),
+	printk(KERN_CONT "and the time interval is %sns (per thread is %sns)", 
+			separate_num((u64)ktime_to_ns(time), char_buff), 
 			separate_num((u64)(ktime_to_ns(time) / num_online_cpus()), char_buff2));
 	printk(KERN_CONT " (%d.%.2d%%)\n", percentage/100, percentage%100);
 }
-
-//unsigned long long calclock(struct timespec *myclock,
-//		unsigned long long *total_time, unsigned long long *total_count)
-//{
-//	unsigned long long timedelay = 0, temp = 0, temp_n = 0;
-//	if (myclock[1].tv_nsec >= myclock[0].tv_nsec) {
-//		temp = myclock[1].tv_sec - myclock[0].tv_sec;
-//		temp_n = myclock[1].tv_nsec - myclock[0].tv_nsec;
-//		timedelay = BILLION * temp + temp_n;
-//	} else {
-//		temp = myclock[1].tv_sec - myclock[0].tv_sec - 1;
-//		temp_n = BILLION + myclock[1].tv_nsec - myclock[0].tv_nsec;
-//		timedelay = BILLION * temp + temp_n;
-//	}
-//	__sync_fetch_and_add(total_time, timedelay);
-//	__sync_fetch_and_add(total_count, 1);
-//	return timedelay;
-//}

--- a/pxt4/calclock.h
+++ b/pxt4/calclock.h
@@ -8,19 +8,20 @@
 #define BILLION 1000000000UL
 #define CONFIG_CALCLOCK
 
-unsigned long long calclock(struct timespec *myclock, 
-		unsigned long long *total_time, unsigned long long *total_clock);
-
 struct calclock {
 	ktime_t time;
 	unsigned long long count;
 };
 
+//unsigned long long calclock(struct timespec *myclock, 
+		unsigned long long *total_time,
+	       	unsigned long long *total_count);
+
 #define KTDEF(funcname) \
-DEFINE_PER_CPU(struct calclock, funcname##_clock) = {0, 0}
+	DEFINE_PER_CPU(struct calclock, funcname##_clock) = {0, 0}
 
 #define KTDEC(funcname) \
-DECLARE_PER_CPU(struct calclock, funcname##_clock)
+	DECLARE_PER_CPU(struct calclock, funcname##_clock)
 
 #ifdef CONFIG_CALCLOCK
 static inline void ktget(ktime_t *clock)
@@ -37,35 +38,35 @@ static inline void __ktput(ktime_t localclocks[], ktime_t *clock_time)
 	*clock_time = ktime_add_safe(*clock_time, diff);
 }
 
-#define ktput(localclocks, funcname)						\
-do {										\
-	struct calclock *clock;							\
-	bool prmpt_enabled = preemptible();					\
-										\
-	if (prmpt_enabled)							\
-		preempt_disable();						\
-	clock = this_cpu_ptr(&(funcname##_clock));				\
-	__ktput(localclocks, &clock->time);					\
-	clock->count++; 							\
-	if (prmpt_enabled)							\
-		put_cpu_ptr(&(funcname##_clock));				\
-} while (0)
+#define ktput(localclocks, funcname)							\
+	do {										\
+		struct calclock *clock;							\
+		bool prmpt_enabled = preemptible();					\
+											\
+		if (prmpt_enabled)							\
+		preempt_disable();							\
+		clock = this_cpu_ptr(&(funcname##_clock));				\
+		__ktput(localclocks, &clock->time);					\
+		clock->count++; 							\
+		if (prmpt_enabled)							\
+		put_cpu_ptr(&(funcname##_clock));					\
+	} while (0)
 
 void __ktprint(int depth, char *func_name, ktime_t time, unsigned long long count);
 
-#define ktprint(depth, funcname)						\
-do {										\
-	int cpu;								\
-	ktime_t timesum = 0;							\
-	unsigned long long countsum = 0;					\
-										\
-	for_each_online_cpu(cpu) {						\
-		struct calclock *clock = per_cpu_ptr(&funcname##_clock, cpu);	\
-		timesum += clock->time;						\
-		countsum += clock->count;					\
-	}									\
-	__ktprint(depth, #funcname, timesum, countsum);				\
-} while (0)
+#define ktprint(depth, funcname)							\
+	do {										\
+		int cpu;								\
+		ktime_t timesum = 0;							\
+		unsigned long long countsum = 0;					\
+											\
+		for_each_online_cpu(cpu) {						\
+			struct calclock *clock = per_cpu_ptr(&funcname##_clock, cpu);	\
+			timesum += clock->time;						\
+			countsum += clock->count;					\
+		}									\
+		__ktprint(depth, #funcname, timesum, countsum);				\
+	} while (0)
 
 #else /* !CONFIG_CALCLOCK */
 #define ktget(clock)

--- a/pxt4/calclock.h
+++ b/pxt4/calclock.h
@@ -1,11 +1,10 @@
 #ifndef __CALCLOCK_H
 #define __CALCLOCK_H
 
-#include <linux/time.h>
 #include <linux/ktime.h>
 #include <linux/percpu.h>
 
-#define BILLION 1000000000UL
+
 #define CONFIG_CALCLOCK
 
 struct calclock {
@@ -13,14 +12,10 @@ struct calclock {
 	unsigned long long count;
 };
 
-//unsigned long long calclock(struct timespec *myclock, 
-		unsigned long long *total_time,
-	       	unsigned long long *total_count);
-
-#define KTDEF(funcname) \
+#define KTDEF(funcname)	\
 	DEFINE_PER_CPU(struct calclock, funcname##_clock) = {0, 0}
 
-#define KTDEC(funcname) \
+#define KTDEC(funcname)	\
 	DECLARE_PER_CPU(struct calclock, funcname##_clock)
 
 #ifdef CONFIG_CALCLOCK
@@ -38,35 +33,35 @@ static inline void __ktput(ktime_t localclocks[], ktime_t *clock_time)
 	*clock_time = ktime_add_safe(*clock_time, diff);
 }
 
-#define ktput(localclocks, funcname)							\
-	do {										\
-		struct calclock *clock;							\
-		bool prmpt_enabled = preemptible();					\
-											\
-		if (prmpt_enabled)							\
-		preempt_disable();							\
-		clock = this_cpu_ptr(&(funcname##_clock));				\
-		__ktput(localclocks, &clock->time);					\
-		clock->count++; 							\
-		if (prmpt_enabled)							\
-		put_cpu_ptr(&(funcname##_clock));					\
-	} while (0)
+#define ktput(localclocks, funcname)						\
+do {										\
+	struct calclock *clock;							\
+	bool prmpt_enabled = preemptible();					\
+										\
+	if (prmpt_enabled)							\
+		preempt_disable();						\
+	clock = this_cpu_ptr(&(funcname##_clock));				\
+	__ktput(localclocks, &clock->time);					\
+	clock->count++; 							\
+	if (prmpt_enabled)							\
+		put_cpu_ptr(&(funcname##_clock));				\
+} while (0)
 
 void __ktprint(int depth, char *func_name, ktime_t time, unsigned long long count);
 
-#define ktprint(depth, funcname)							\
-	do {										\
-		int cpu;								\
-		ktime_t timesum = 0;							\
-		unsigned long long countsum = 0;					\
-											\
-		for_each_online_cpu(cpu) {						\
-			struct calclock *clock = per_cpu_ptr(&funcname##_clock, cpu);	\
-			timesum += clock->time;						\
-			countsum += clock->count;					\
-		}									\
-		__ktprint(depth, #funcname, timesum, countsum);				\
-	} while (0)
+#define ktprint(depth, funcname)						\
+do {										\
+	int cpu;								\
+	ktime_t timesum = 0;							\
+	unsigned long long countsum = 0;					\
+										\
+	for_each_online_cpu(cpu) {						\
+		struct calclock *clock = per_cpu_ptr(&funcname##_clock, cpu);	\
+		timesum += clock->time;						\
+		countsum += clock->count;					\
+	}									\
+	__ktprint(depth, #funcname, timesum, countsum);				\
+} while (0)
 
 #else /* !CONFIG_CALCLOCK */
 #define ktget(clock)

--- a/pxt4/calclock.h
+++ b/pxt4/calclock.h
@@ -2,10 +2,78 @@
 #define __CALCLOCK_H
 
 #include <linux/time.h>
+#include <linux/ktime.h>
+#include <linux/percpu.h>
 
 #define BILLION 1000000000UL
+#define CONFIG_CALCLOCK
 
 unsigned long long calclock(struct timespec *myclock, 
 		unsigned long long *total_time, unsigned long long *total_clock);
 
-#endif
+struct calclock {
+	ktime_t time;
+	unsigned long long count;
+};
+
+#define KTDEF(funcname) \
+DEFINE_PER_CPU(struct calclock, funcname##_clock) = {0, 0}
+
+#define KTDEC(funcname) \
+DECLARE_PER_CPU(struct calclock, funcname##_clock)
+
+#ifdef CONFIG_CALCLOCK
+static inline void ktget(ktime_t *clock)
+{
+	*clock = ktime_get_raw();
+}
+
+static inline void __ktput(ktime_t localclocks[], ktime_t *clock_time)
+{
+	ktime_t diff;
+
+	BUG_ON(ktime_after(localclocks[0], localclocks[1]));
+	diff = ktime_sub(localclocks[1], localclocks[0]);
+	*clock_time = ktime_add_safe(*clock_time, diff);
+}
+
+#define ktput(localclocks, funcname)						\
+do {										\
+	struct calclock *clock;							\
+	bool prmpt_enabled = preemptible();					\
+										\
+	if (prmpt_enabled)							\
+		preempt_disable();						\
+	clock = this_cpu_ptr(&(funcname##_clock));				\
+	__ktput(localclocks, &clock->time);					\
+	clock->count++; 							\
+	if (prmpt_enabled)							\
+		put_cpu_ptr(&(funcname##_clock));				\
+} while (0)
+
+void __ktprint(int depth, char *func_name, ktime_t time, unsigned long long count);
+
+#define ktprint(depth, funcname)						\
+do {										\
+	int cpu;								\
+	ktime_t timesum = 0;							\
+	unsigned long long countsum = 0;					\
+										\
+	for_each_online_cpu(cpu) {						\
+		struct calclock *clock = per_cpu_ptr(&funcname##_clock, cpu);	\
+		timesum += clock->time;						\
+		countsum += clock->count;					\
+	}									\
+	__ktprint(depth, #funcname, timesum, countsum);				\
+} while (0)
+
+#else /* !CONFIG_CALCLOCK */
+#define ktget(clock)
+#define ktput(localclock, funcname)
+#define ktprint(depth, funcname)
+#endif /* CONFIG_CALCLOCK */
+
+#define calclock(a, b, c)
+#define CALCLOCK_DEF(a)
+
+#endif /* __CALCLOCK_H */

--- a/pxt4/file.c
+++ b/pxt4/file.c
@@ -308,16 +308,22 @@ static void print_cpu_dm(unsigned long id, const char * name, unsigned long long
 DEFINE_DS_MONITORING(cpu_dm, get_cpu_id, get_cpu_name,  print_cpu_dm);
 unsigned long long file_write_iter_time, file_write_iter_count;
 
+KTDEF(pxt4_file_write_iter_internal);
 static ssize_t pxt4_file_write_iter(struct kiocb *iocb, struct iov_iter *from) {
 	ssize_t ret;
-	struct timespec myclock[2];
+	//struct timespec myclock[2];
+	ktime_t stopwatch[2];
 
-	getrawmonotonic(&myclock[0]);
+	//getrawmonotonic(&myclock[0]);
+	ktget(&stopwatch[0]);
 	ret = pxt4_file_write_iter_internal(iocb, from);
-	getrawmonotonic(&myclock[1]);
-	calclock(myclock, &file_write_iter_time, &file_write_iter_count);
+	//getrawmonotonic(&myclock[1]);
+	ktget(&stopwatch[1]);
+	//calclock(myclock, &file_write_iter_time, &file_write_iter_count);
+	ktput(stopwatch, pxt4_file_write_iter_internal);
+
 	//printk("cpu[%d] called pxt4_file_write_iter()",current->cpu);
-	find_ds_monitoring(&cpu_dm, current);
+	//find_ds_monitoring(&cpu_dm, current);
 	return ret;
 }
 

--- a/pxt4/super.c
+++ b/pxt4/super.c
@@ -6337,7 +6337,9 @@ out7:
 #include "ds_monitoring.h"
 DECLARE_DS_MONITORING(cpu_dm);
 
+#include "calclock.h"
 extern unsigned long long file_write_iter_time, file_write_iter_count;
+KTDEC(pxt4_file_write_iter_internal);
 static void __exit pxt4_exit_fs(void)
 {
 	pxt4_destroy_lazyinit_thread();
@@ -6353,9 +6355,10 @@ static void __exit pxt4_exit_fs(void)
 	pxt4_exit_es();
 	pxt4_exit_pending();
 
-	printk("pxt4_file_write_iter is called %llu times and the time interval is %lluns\n", file_write_iter_count, file_write_iter_time);
-	print_ds_monitoring(&cpu_dm);
-	delete_ds_monitoring(&cpu_dm);
+	//printk("pxt4_file_write_iter is called %llu times and the time interval is %lluns\n", file_write_iter_count, file_write_iter_time);
+	ktprint(1, pxt4_file_write_iter_internal);
+	//print_ds_monitoring(&cpu_dm);
+	//delete_ds_monitoring(&cpu_dm);
 }
 
 MODULE_AUTHOR("Remy Card, Stephen Tweedie, Andrew Morton, Andreas Dilger, Theodore Ts'o and others");


### PR DESCRIPTION
- adding original calclock: can degrade system performance
- adding per-core clock: doesn't much affect system performance
- calclock.h
  - define CONFIG_CALCLOCK
  - calclock structure
    - time: time interval of the function being measured
    - count: the number of this calclock called by its thread
  - KTDEF: defining a new calclock
  - KTDEC: declaring an existing calclock defined in another file
  - ktget: gets current time & saves it into a local clock(ktime_t)
  - ktput: gets current per-core calclock & calculates time interval
  - ktprint: prints total time and counts of the per-core calclock